### PR TITLE
Add test for tooltip generation

### DIFF
--- a/projects/angular-gradient-progressbar/src/lib/angular-gradient-progressbar.component.spec.ts
+++ b/projects/angular-gradient-progressbar/src/lib/angular-gradient-progressbar.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { AngularGradientProgressbarComponent } from './angular-gradient-progressbar.component';
 
@@ -6,7 +6,7 @@ describe('AngularGradientProgressbarComponent', () => {
   let component: AngularGradientProgressbarComponent;
   let fixture: ComponentFixture<AngularGradientProgressbarComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ AngularGradientProgressbarComponent ]
     })

--- a/projects/angular-gradient-progressbar/src/lib/angular-gradient-progressbar.component.spec.ts
+++ b/projects/angular-gradient-progressbar/src/lib/angular-gradient-progressbar.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 
 import { AngularGradientProgressbarComponent } from './angular-gradient-progressbar.component';
 
@@ -22,4 +22,28 @@ describe('AngularGradientProgressbarComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should render tooltip based on value and quartiles', fakeAsync(() => {
+    component.type = 1;
+    component.barCount = 10;
+
+    component.quartileValueLow = 3; // everything below 30 becomes "low"
+    component.quartileValueHigh = 7; // everything between 30 and 70 becomes "medium"
+
+    setValue(component, 10);
+    expect(component.potentialLabel).toBe('low');
+
+    setValue(component, 50);
+    expect(component.potentialLabel).toBe('medium');
+
+    setValue(component, 90);
+    expect(component.potentialLabel).toBe('high');
+  }));
+
+  function setValue(component: AngularGradientProgressbarComponent, value: number) {
+    component.value = value;
+    component.ngAfterViewInit();
+    tick();
+  }
 });
+

--- a/projects/angular-gradient-progressbar/src/test.ts
+++ b/projects/angular-gradient-progressbar/src/test.ts
@@ -20,7 +20,3 @@ getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting()
 );
-// Then we find all the tests.
-const context = require.context('./', true, /\.spec\.ts$/);
-// And load the modules.
-context.keys().map(context);


### PR DESCRIPTION
This PR adds a test to verify that the generation of the tooltip text works as expected. It also fixes tests not being executed when running `ng test` and removes a deprecation warning.